### PR TITLE
Point GHA tests to Pyomo master

### DIFF
--- a/.github/workflows/pr_master_test.yml
+++ b/.github/workflows/pr_master_test.yml
@@ -340,8 +340,7 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         # Test against a branch until PySP is actually removed from Pyomo
-        # $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
-        $PYTHON_EXE -m pip install git+https://github.com/jsiirola/pyomo@remove-pysp
+        $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
         echo ""
         echo "Install PySP..."
         echo ""
@@ -463,8 +462,7 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         # Test against a branch until PySP is actually removed from Pyomo
-        # $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
-        $PYTHON_EXE -m pip install git+https://github.com/jsiirola/pyomo@remove-pysp
+        $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
         echo ""
         echo "Install PySP..."
         echo ""

--- a/.github/workflows/push_branch_test.yml
+++ b/.github/workflows/push_branch_test.yml
@@ -335,8 +335,7 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         # Test against a branch until PySP is actually removed from Pyomo
-        # $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
-        $PYTHON_EXE -m pip install git+https://github.com/jsiirola/pyomo@remove-pysp
+        $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
         echo ""
         echo "Install PySP..."
         echo ""
@@ -458,8 +457,7 @@ jobs:
         echo "Install Pyomo..."
         echo ""
         # Test against a branch until PySP is actually removed from Pyomo
-        # $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
-        $PYTHON_EXE -m pip install git+https://github.com/jsiirola/pyomo@remove-pysp
+        $PYTHON_EXE -m pip install git+https://github.com/Pyomo/pyomo
         echo ""
         echo "Install PySP..."
         echo ""


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
Now that Pyomo/pyomo#1819 has been merged, PySP can build against the Pyomo master branch.

## Changes proposed in this PR:
- Update GHA builds to use Pyomo master branch

### Legal Acknowledgement

By contributing to this software project, I have read the [Pyomo contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
